### PR TITLE
Route override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - sudo /etc/init.d/rethinkdb restart
 language: node_js
 node_js:
-- '6'
+- '6.5'
 env:
 - SLOW_TEST=true CXX=g++-4.8
 addons:

--- a/resource/src/routes/route.mustache
+++ b/resource/src/routes/route.mustache
@@ -1,6 +1,5 @@
-const { createRouter } = require('../utils/router');
+const { createRouter, objToRouter } = require('../utils/router');
 const {{camelCasePlural}} = require('../controllers/{{snakeCasePlural}}');
-const { Router } = require('express');
 
 const serialize = {{camelCase}} => {
   const data = Object.assign({}, {{camelCase}});
@@ -11,8 +10,6 @@ const serialize = {{camelCase}} => {
 };
 
 const routerTemplate = createRouter({{camelCasePlural}}, serialize);
-
-const router = new Router();
 
 {{#isUser}}
 routerTemplate.post['/signin'] = function *(req, res) {
@@ -25,14 +22,6 @@ routerTemplate.post['/signout'] = function *(req, res) {
 };
 {{/isUser}}
 
-Object.keys(routerTemplate).forEach(method => {
-  if (method === 'socket') return;
-  Object.keys(routerTemplate[method]).forEach(route => {
-    const handler = routerTemplate[method][route];
-    router[method](route, handler);
-  });
-});
-
-router.socket = routerTemplate.socket;
+const router = objToRouter(routerTemplate);
 
 module.exports = router;

--- a/resource/src/routes/route.mustache
+++ b/resource/src/routes/route.mustache
@@ -1,5 +1,6 @@
 const { createRouter } = require('../utils/router');
 const {{camelCasePlural}} = require('../controllers/{{snakeCasePlural}}');
+const { Router } = require('express');
 
 const serialize = {{camelCase}} => {
   const data = Object.assign({}, {{camelCase}});
@@ -9,13 +10,29 @@ const serialize = {{camelCase}} => {
   return data;
 };
 
-module.exports = createRouter({{camelCasePlural}}, serialize){{^isUser}};{{/isUser}}
-  {{#isUser}}
-  .post('/signin', function *(req, res) {
-    const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
-    res.json({ token, user: serialize(user) });
-  })
-  .post('/signout', function *(req, res) {
-    res.json(yield {{camelCasePlural}}.signout(req.body));
+const routerTemplate = createRouter({{camelCasePlural}}, serialize);
+
+const router = new Router();
+
+{{#isUser}}
+routerTemplate.post['/signin'] = function *(req, res) {
+  const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
+  res.json({ token, user: serialize(user) });
+};
+
+routerTemplate.post['/signout'] = function *(req, res) {
+  res.json(yield {{camelCasePlural}}.signout(req.body));
+};
+{{/isUser}}
+
+Object.keys(routerTemplate).forEach(method => {
+  if (method === 'socket') return;
+  Object.keys(routerTemplate[method]).forEach(route => {
+    const handler = routerTemplate[method][route];
+    router[method](route, handler);
   });
-  {{/isUser}}
+});
+
+router.socket = routerTemplate.socket;
+
+module.exports = router;

--- a/resource/src/routes/route.mustache
+++ b/resource/src/routes/route.mustache
@@ -1,4 +1,4 @@
-const { createRouter, objToRouter } = require('../utils/router');
+const { createRouter } = require('../utils/router');
 const {{camelCasePlural}} = require('../controllers/{{snakeCasePlural}}');
 
 const serialize = {{camelCase}} => {
@@ -9,19 +9,18 @@ const serialize = {{camelCase}} => {
   return data;
 };
 
-const routerTemplate = createRouter({{camelCasePlural}}, serialize);
-
 {{#isUser}}
-routerTemplate.post['/signin'] = function *(req, res) {
-  const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
-  res.json({ token, user: serialize(user) });
-};
-
-routerTemplate.post['/signout'] = function *(req, res) {
-  res.json(yield {{camelCasePlural}}.signout(req.body));
+const template = {
+  post: {
+    '/signin': function *(req, res) {
+      const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
+      res.json({ token, user: serialize(user) });
+    },
+    '/signout': function *(req, res) {
+      res.json(yield {{camelCasePlural}}.signout(req.body));
+    }
+  }
 };
 {{/isUser}}
 
-const router = objToRouter(routerTemplate);
-
-module.exports = router;
+module.exports = createRouter({{camelCasePlural}}, serialize{{#isUser}}, template{{/isUser}});

--- a/resource/src/routes/route.mustache
+++ b/resource/src/routes/route.mustache
@@ -1,26 +1,33 @@
+{{#isUser}}
+const { Router } = require('express');
+{{/isUser}}
 const { createRouter } = require('../utils/router');
 const {{camelCasePlural}} = require('../controllers/{{snakeCasePlural}}');
 
+{{#isUser}}
 const serialize = {{camelCase}} => {
   const data = Object.assign({}, {{camelCase}});
-  {{#isUser}}
   delete data.password;
-  {{/isUser}}
   return data;
 };
 
-{{#isUser}}
-const template = {
-  post: {
-    '/signin': function *(req, res) {
-      const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
-      res.json({ token, user: serialize(user) });
-    },
-    '/signout': function *(req, res) {
-      res.json(yield {{camelCasePlural}}.signout(req.body));
-    }
-  }
-};
+const customRouter = new Router()
+  .post('/signin', function *(req, res) {
+    const { user, token } = yield {{camelCasePlural}}.signin(req.body.email, req.body.password);
+    res.json({ token, user: serialize(user) });
+  })
+  .post('/signout', function *(req, res) {
+    res.json(yield {{camelCasePlural}}.signout(req.body));
+  });
+
+const defaultRouter = createRouter({{camelCasePlural}}, serialize);
+customRouter.socket = defaultRouter.socket;
+
+customRouter.use(defaultRouter);
+
+module.exports = customRouter;
 {{/isUser}}
 
-module.exports = createRouter({{camelCasePlural}}, serialize{{#isUser}}, template{{/isUser}});
+{{^isUser}}
+module.exports = createRouter({{camelCasePlural}});
+{{/isUser}}

--- a/resource/src/utils/router.mustache
+++ b/resource/src/utils/router.mustache
@@ -1,4 +1,5 @@
 const { nullToUndefined } = require('./helpers');
+const { Router } = require('express');
 
 const defaultSerializer = record => Object.assign({}, record);
 
@@ -51,6 +52,22 @@ exports.createRouter = (controller, serialize = defaultSerializer) => {
       return feed;
     }
   };
+
+  return router;
+};
+
+exports.objToRouter = (routerTemplate) => {
+  const router = new Router();
+
+  Object.keys(routerTemplate).forEach(method => {
+    if (method === 'socket') return;
+    Object.keys(routerTemplate[method]).forEach(route => {
+      const handler = routerTemplate[method][route];
+      router[method](route, handler);
+    });
+  });
+
+  router.socket = routerTemplate.socket;
 
   return router;
 };

--- a/resource/src/utils/router.mustache
+++ b/resource/src/utils/router.mustache
@@ -1,75 +1,49 @@
 const { nullToUndefined } = require('./helpers');
 const { Router } = require('express');
-const { merge } = require('lodash');
 
 const defaultSerializer = record => Object.assign({}, record);
 
-exports.createRouter = (controller, serialize = defaultSerializer, template = {}) => {
-  const router = merge({
-    get: {
-      '': function *(req, res) {
-        const list = yield controller.all(req.query);
-        res.json(list.map(serialize));
-      },
-      '/:id': function *(req, res) {
-        const record = yield controller.find(req.params.id);
-        res.json(serialize(record));
-      }
-    },
-    post: {
-      '': function *(req, res) {
-        const record = yield controller.create(req.body);
-        res.status(201).json(serialize(record));
-      }
-    },
-    put: {
-      '/:id': function *(req, res) {
-        const record = yield controller.replace(req.params.id, req.body);
-        res.json(serialize(record));
-      }
-    },
-    patch: {
-      '/:id': function *(req, res) {
-        const replaced = nullToUndefined(req.body);
-        const record = yield controller.update(req.params.id, replaced);
-        res.json(serialize(record));
-      }
-    },
-    delete: {
-      '/:id': function *(req, res) {
-        const record = yield controller.delete(req.params.id);
-        res.json(serialize(record));
-      }
-    },
-    *socket(socket, req) {
-      const { feed, count } = yield controller.watch(req.query);
-      socket.emit('metadata', { count });
-
-      feed.listen((err, event, record) => {
-        if (err) throw err;
-        socket.emit(event, serialize(record));
-      });
-
-      return feed;
-    }
-  }, template);
-
-  return objToRouter(router);
-};
-
-function objToRouter(routerTemplate) {
+exports.createRouter = (controller, serialize = defaultSerializer) => {
   const router = new Router();
 
-  Object.keys(routerTemplate).forEach(method => {
-    if (method === 'socket') return;
-    Object.keys(routerTemplate[method]).forEach(route => {
-      const handler = routerTemplate[method][route];
-      if (!handler) return;
-      router[method](route, handler);
+  router
+    .get('', function *(req, res) {
+      const list = yield controller.all(req.query);
+      res.json(list.map(serialize));
+    })
+    .get('/:id', function *(req, res) {
+      const record = yield controller.find(req.params.id);
+      res.json(serialize(record));
+    })
+    .post('', function *(req, res) {
+      const record = yield controller.create(req.body);
+      res.status(201).json(serialize(record));
+    })
+    .put('/:id', function *(req, res) {
+      const record = yield controller.replace(req.params.id, req.body);
+      res.json(serialize(record));
+    })
+    .patch('/:id', function *(req, res) {
+      const replaced = nullToUndefined(req.body);
+      const record = yield controller.update(req.params.id, replaced);
+      res.json(serialize(record));
+    })
+    .delete('/:id', function *(req, res) {
+      const record = yield controller.delete(req.params.id);
+      res.json(serialize(record));
     });
-  });
 
-  router.socket = routerTemplate.socket;
+  router.socket = function *(socket, req) {
+    const { feed, count } = yield controller.watch(req.query);
+    socket.emit('metadata', { count });
+
+    feed.listen((err, event, record) => {
+      if (err) throw err;
+      socket.emit(event, serialize(record));
+    });
+
+    return feed;
+  };
 
   return router;
-}
+};

--- a/resource/src/utils/router.mustache
+++ b/resource/src/utils/router.mustache
@@ -1,46 +1,55 @@
-const { Router } = require('express');
 const { nullToUndefined } = require('./helpers');
 
 const defaultSerializer = record => Object.assign({}, record);
 
 exports.createRouter = (controller, serialize = defaultSerializer) => {
-  const router = new Router()
-    .get('', function *(req, res) {
-      const list = yield controller.all(req.query);
-      res.json(list.map(serialize));
-    })
-    .get('/:id', function *(req, res) {
-      const record = yield controller.find(req.params.id);
-      res.json(serialize(record));
-    })
-    .post('', function *(req, res) {
-      const record = yield controller.create(req.body);
-      res.status(201).json(serialize(record));
-    })
-    .put('/:id', function *(req, res) {
-      const record = yield controller.replace(req.params.id, req.body);
-      res.json(serialize(record));
-    })
-    .patch('/:id', function *(req, res) {
-      const replaced = nullToUndefined(req.body);
-      const record = yield controller.update(req.params.id, replaced);
-      res.json(serialize(record));
-    })
-    .delete('/:id', function *(req, res) {
-      const record = yield controller.delete(req.params.id);
-      res.json(serialize(record));
-    });
+  const router = {
+    get: {
+      '': function *(req, res) {
+        const list = yield controller.all(req.query);
+        res.json(list.map(serialize));
+      },
+      '/:id': function *(req, res) {
+        const record = yield controller.find(req.params.id);
+        res.json(serialize(record));
+      }
+    },
+    post: {
+      '': function *(req, res) {
+        const record = yield controller.create(req.body);
+        res.status(201).json(serialize(record));
+      }
+    },
+    put: {
+      '/:id': function *(req, res) {
+        const record = yield controller.replace(req.params.id, req.body);
+        res.json(serialize(record));
+      }
+    },
+    patch: {
+      '/:id': function *(req, res) {
+        const replaced = nullToUndefined(req.body);
+        const record = yield controller.update(req.params.id, replaced);
+        res.json(serialize(record));
+      }
+    },
+    delete: {
+      '/:id': function *(req, res) {
+        const record = yield controller.delete(req.params.id);
+        res.json(serialize(record));
+      }
+    },
+    *socket(socket, req) {
+      const { feed, count } = yield controller.watch(req.query);
+      socket.emit('metadata', { count });
 
-  router.socket = function *(socket, req) {
-    const { feed, count } = yield controller.watch(req.query);
-    socket.emit('metadata', { count });
+      feed.listen((err, event, record) => {
+        if (err) throw err;
+        socket.emit(event, serialize(record));
+      });
 
-    feed.listen((err, event, record) => {
-      if (err) throw err;
-      socket.emit(event, serialize(record));
-    });
-
-    return feed;
+      return feed;
+    }
   };
 
   return router;

--- a/resource/src/utils/router.mustache
+++ b/resource/src/utils/router.mustache
@@ -1,10 +1,11 @@
 const { nullToUndefined } = require('./helpers');
 const { Router } = require('express');
+const { merge } = require('lodash');
 
 const defaultSerializer = record => Object.assign({}, record);
 
-exports.createRouter = (controller, serialize = defaultSerializer) => {
-  const router = {
+exports.createRouter = (controller, serialize = defaultSerializer, template = {}) => {
+  const router = merge({
     get: {
       '': function *(req, res) {
         const list = yield controller.all(req.query);
@@ -51,18 +52,19 @@ exports.createRouter = (controller, serialize = defaultSerializer) => {
 
       return feed;
     }
-  };
+  }, template);
 
-  return router;
+  return objToRouter(router);
 };
 
-exports.objToRouter = (routerTemplate) => {
+function objToRouter(routerTemplate) {
   const router = new Router();
 
   Object.keys(routerTemplate).forEach(method => {
     if (method === 'socket') return;
     Object.keys(routerTemplate[method]).forEach(route => {
       const handler = routerTemplate[method][route];
+      if (!handler) return;
       router[method](route, handler);
     });
   });
@@ -70,4 +72,4 @@ exports.objToRouter = (routerTemplate) => {
   router.socket = routerTemplate.socket;
 
   return router;
-};
+}


### PR DESCRIPTION
This is a suggested pattern for abstracting the default router template logic away from the action of actually instantiating the `Router`. The `createRouter` method now returns a dict of the form:

```
{
  method: {
    'routeString': handlerFunction
  }
}
```

Properties in the dict can then be easily overridden before handing the template to another util function which takes the config and instantiates it into a `Router`.

The glass half empty view on this is that we've just created a weird little internal DSL and that's gross. The glass half full view is that this is just a struct and that's totally fine and we're making Ken Thompson proud.

The way it's structured allows modification of the routes before the router is instantiated, but then also exposes the instantiated router for extra methods to be added to the middleware stack after line 25 of `src/routes/route/mustache`.

I can't see a method that gives us a better flexibility to boilerplate ratio.
